### PR TITLE
feat: noir support

### DIFF
--- a/packages/compiler/src/bin/compiler.rs
+++ b/packages/compiler/src/bin/compiler.rs
@@ -60,7 +60,7 @@ enum Commands {
     Decomposed {
         #[arg(short, long)]
         decomposed_regex_path: String,
-        #[arg(short, long)]
+        #[arg(long)]
         halo2_dir_path: Option<String>,
         #[arg(short, long)]
         circom_file_path: Option<String>,
@@ -74,7 +74,7 @@ enum Commands {
         raw_regex: String,
         #[arg(short, long)]
         substrs_json_path: Option<String>,
-        #[arg(short, long)]
+        #[arg(long)]
         halo2_dir_path: Option<String>,
         #[arg(short, long)]
         circom_file_path: Option<String>,

--- a/packages/compiler/src/bin/compiler.rs
+++ b/packages/compiler/src/bin/compiler.rs
@@ -66,6 +66,8 @@ enum Commands {
         circom_file_path: Option<String>,
         #[arg(short, long)]
         template_name: Option<String>,
+        #[arg(long)]
+        noir_file_path: Option<String>,
         #[arg(short, long)]
         gen_substrs: Option<bool>,
     },
@@ -80,6 +82,8 @@ enum Commands {
         circom_file_path: Option<String>,
         #[arg(short, long)]
         template_name: Option<String>,
+        #[arg(long)]
+        noir_file_path: Option<String>,
         #[arg(short, long)]
         gen_substrs: Option<bool>,
     },
@@ -99,6 +103,7 @@ fn process_decomposed(cli: Cli) {
         halo2_dir_path,
         circom_file_path,
         template_name,
+        noir_file_path,
         gen_substrs,
     } = cli.command
     {
@@ -107,6 +112,7 @@ fn process_decomposed(cli: Cli) {
             halo2_dir_path.as_deref(),
             circom_file_path.as_deref(),
             template_name.as_deref(),
+            noir_file_path.as_deref(),
             gen_substrs,
         ) {
             eprintln!("Error: {}", e);
@@ -122,6 +128,7 @@ fn process_raw(cli: Cli) {
         halo2_dir_path,
         circom_file_path,
         template_name,
+        noir_file_path,
         gen_substrs,
     } = cli.command
     {
@@ -131,6 +138,7 @@ fn process_raw(cli: Cli) {
             halo2_dir_path.as_deref(),
             circom_file_path.as_deref(),
             template_name.as_deref(),
+            noir_file_path.as_deref(),
             gen_substrs,
         ) {
             eprintln!("Error: {}", e);

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -79,7 +79,7 @@ comptime fn make_lookup_table() -> [Field; {table_size}] {{
         .join(" | ");
     let fn_body = format!(
         r#"
-global table = make_lookup_table();
+global table = comptime {{ make_lookup_table() }};
 pub fn regex_match<let N: u32>(input: [u8; N]) {{
     // regex: {regex_pattern}
     let mut s = 0;

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -1,0 +1,100 @@
+use std::{fs::File, io::Write, path::Path};
+
+use crate::structs::RegexAndDFA;
+
+pub fn gen_noir_fn(regex_and_dfa: &RegexAndDFA, path: &Path) -> Result<(), std::io::Error> {
+    let noir_fn = to_noir_fn(regex_and_dfa);
+    let mut file = File::create(path)?;
+    file.write_all(noir_fn.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
+    let accept_state_id = {
+        let last_state = regex_and_dfa.dfa.states.last().expect("no last state");
+        assert!(
+            last_state.state_type == "accept",
+            "last state is accept, right??"
+        );
+        last_state.state_id
+    };
+
+    const BYTE_SIZE: u32 = 256; // u8 size
+    let mut lookup_table_body = String::new();
+
+    // curr_state + char_code -> next_state
+    let mut rows: Vec<(usize, u8, usize)> = vec![];
+
+    for state in regex_and_dfa.dfa.states.iter() {
+        if state.state_type == "accept" {
+            assert_eq!(state.transitions.len(), 0, "accept state has transitions");
+        } else {
+            assert!(state.transitions.len() > 0, "no transitions");
+            for (&tran_next_state_id, tran) in &state.transitions {
+                for &char_code in tran {
+                    rows.push((state.state_id, char_code, tran_next_state_id));
+                }
+            }
+        };
+    }
+
+    for (curr_state_id, char_code, next_state_id) in rows {
+        lookup_table_body +=
+            &format!("table[{curr_state_id} * {BYTE_SIZE} + {char_code}] = {next_state_id};\n",);
+    }
+
+    lookup_table_body = indent(&lookup_table_body);
+    let table_size = BYTE_SIZE as usize * regex_and_dfa.dfa.states.len();
+    let lookup_table = format!(
+        r#"
+comptime fn make_lookup_table() -> [Field; {table_size}] {{
+    let mut table = [0; {table_size}];
+{lookup_table_body}
+
+    // experimentally confirmed that storing a transition for each char code for accept state produces less gates than adding an `if` to check if the current state is not "accept"
+    // I might be wrong. I tested for input of length 128 and 1024.
+    for i in 0..{BYTE_SIZE} {{
+        table[{accept_state_id} * {BYTE_SIZE} + i] = {accept_state_id};
+    }}
+    table
+}}
+    "#
+    );
+
+    let fn_body = format!(
+        r#"
+global table = make_lookup_table();
+pub fn regex_match<let N: u32>(input: [u8; N]) {{
+    // regex: {regex_pattern}
+    let mut s = 0;
+    for i in 0..input.len() {{
+        s = table[s * {BYTE_SIZE} + input[i] as Field];
+    }}
+    assert_eq(s, {accept_state_id}, f"no match: {{s}}");
+}}
+    "#,
+        regex_pattern = regex_and_dfa.regex_pattern,
+    );
+    format!(
+        r#"
+        {fn_body}
+        {lookup_table}
+    "#
+    )
+    .trim()
+    .to_owned()
+}
+
+fn indent(s: &str) -> String {
+    s.split("\n")
+        .map(|s| {
+            if s.trim().is_empty() {
+                s.to_owned()
+            } else {
+                format!("{}{}", "    ", s)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -1,6 +1,10 @@
-use std::{fs::File, io::Write, path::Path};
+use std::{collections::HashSet, fs::File, io::Write, iter::FromIterator, path::Path};
+
+use itertools::Itertools;
 
 use crate::structs::RegexAndDFA;
+
+const ACCEPT_STATE_ID: &str = "accept";
 
 pub fn gen_noir_fn(regex_and_dfa: &RegexAndDFA, path: &Path) -> Result<(), std::io::Error> {
     let noir_fn = to_noir_fn(regex_and_dfa);
@@ -11,13 +15,16 @@ pub fn gen_noir_fn(regex_and_dfa: &RegexAndDFA, path: &Path) -> Result<(), std::
 }
 
 fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
-    let accept_state_id = {
-        let last_state = regex_and_dfa.dfa.states.last().expect("no last state");
-        assert!(
-            last_state.state_type == "accept",
-            "last state is accept, right??"
-        );
-        last_state.state_id
+    let accept_state_ids = {
+        let accept_states = regex_and_dfa
+            .dfa
+            .states
+            .iter()
+            .filter(|s| s.state_type == ACCEPT_STATE_ID)
+            .map(|s| s.state_id)
+            .collect_vec();
+        assert!(accept_states.len() > 0, "no accept states");
+        accept_states
     };
 
     const BYTE_SIZE: u32 = 256; // u8 size
@@ -27,16 +34,24 @@ fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
     let mut rows: Vec<(usize, u8, usize)> = vec![];
 
     for state in regex_and_dfa.dfa.states.iter() {
-        if state.state_type == "accept" {
-            assert_eq!(state.transitions.len(), 0, "accept state has transitions");
-        } else {
-            assert!(state.transitions.len() > 0, "no transitions");
-            for (&tran_next_state_id, tran) in &state.transitions {
-                for &char_code in tran {
-                    rows.push((state.state_id, char_code, tran_next_state_id));
-                }
+        for (&tran_next_state_id, tran) in &state.transitions {
+            for &char_code in tran {
+                rows.push((state.state_id, char_code, tran_next_state_id));
             }
-        };
+        }
+        if state.state_type == ACCEPT_STATE_ID {
+            let existing_char_codes = &state
+                .transitions
+                .iter()
+                .flat_map(|(_, tran)| tran.iter().copied().collect_vec())
+                .collect::<HashSet<_>>();
+            let all_char_codes = HashSet::from_iter(0..=255);
+            let mut char_codes = all_char_codes.difference(existing_char_codes).collect_vec();
+            char_codes.sort(); // to be deterministic
+            for &char_code in char_codes {
+                rows.push((state.state_id, char_code, state.state_id));
+            }
+        }
     }
 
     for (curr_state_id, char_code, next_state_id) in rows {
@@ -52,16 +67,16 @@ comptime fn make_lookup_table() -> [Field; {table_size}] {{
     let mut table = [0; {table_size}];
 {lookup_table_body}
 
-    // experimentally confirmed that storing a transition for each char code for accept state produces less gates than adding an `if` to check if the current state is not "accept"
-    // I might be wrong. I tested for input of length 128 and 1024.
-    for i in 0..{BYTE_SIZE} {{
-        table[{accept_state_id} * {BYTE_SIZE} + i] = {accept_state_id};
-    }}
     table
 }}
     "#
     );
 
+    let final_states_condition_body = accept_state_ids
+        .iter()
+        .map(|id| format!("(s == {id})"))
+        .collect_vec()
+        .join(" | ");
     let fn_body = format!(
         r#"
 global table = make_lookup_table();
@@ -71,7 +86,7 @@ pub fn regex_match<let N: u32>(input: [u8; N]) {{
     for i in 0..input.len() {{
         s = table[s * {BYTE_SIZE} + input[i] as Field];
     }}
-    assert_eq(s, {accept_state_id}, f"no match: {{s}}");
+    assert({final_states_condition_body}, f"no match: {{s}}");
 }}
     "#,
         regex_pattern = regex_and_dfa.regex_pattern,


### PR DESCRIPTION
Adds noir support to zk-regex.

To test:
1. `git clone https://github.com/olehmisar/zk-regex.git`
2. `git checkout noir`
3. `cd packages/compiler`
4. `cargo run --bin zk-regex raw -r "m[10]-[ab]+;" --noir-file-path my_file.nr`

Missing features:
- [ ] `gen_substrs`
- [ ] I did not test `^` and `$` and overall, not a lot of testing was conducted
- [ ] lookup table optimization