### PR TITLE
Caret anchor support (^)

### DIFF
--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -83,6 +83,7 @@ global table = comptime {{ make_lookup_table() }};
 pub fn regex_match<let N: u32>(input: [u8; N]) {{
     // regex: {regex_pattern}
     let mut s = 0;
+    s = table[s * 256 + 255 as Field];
     for i in 0..input.len() {{
         s = table[s * {BYTE_SIZE} + input[i] as Field];
     }}


### PR DESCRIPTION
#2 was based on a squashed branch, so I re-open with same commits based on the main branch

Original description:

Added support for `ˆ` and `$`.

## Caret Anchor
`^` causes the DFA to contain an extra state beforehand that has a transition for `255`, which marks the start of the input byte array. In the `regex_match` function the `input` is then prefixed with `255` to execute the check. This implementation follows the one of circom.

## End Anchor
If `$` is present at the end of the regex, `has_end_anchor` is set to true in the `RegexAndDFA`. To support this using the lookup table we added another 256 entries, which map any byte after the `accept_state_id` to an `invalid_state`. This fix works now, but we need to retest when the fix for "multiple accept states" is there -> this is why it is a draft for now. 