### PR TITLE
Added `gen_substrs` support

### DIFF
--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -90,7 +90,7 @@ fn generate_outputs(
     }
 
     if let Some(noir_file_path) = noir_file_path {
-        gen_noir_fn(regex_and_dfa, &PathBuf::from(noir_file_path))?;
+        gen_noir_fn(regex_and_dfa, &PathBuf::from(noir_file_path), gen_substrs)?;
     }
 
     Ok(())

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -170,7 +170,7 @@ pub fn gen_from_raw(
 
     let regex_and_dfa = create_regex_and_dfa_from_str_and_defs(raw_regex, substrs_defs_json)?;
 
-    let gen_substrs = gen_substrs.unwrap_or(true);
+    let gen_substrs = gen_substrs.unwrap_or(false);
 
     generate_outputs(
         &regex_and_dfa,

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -1,20 +1,32 @@
-use std::{collections::HashSet, fs::File, io::Write, iter::FromIterator, path::Path};
-
-use itertools::Itertools;
-
 use crate::structs::RegexAndDFA;
+use itertools::Itertools;
+use std::{collections::HashSet, fs::File, io::Write, iter::FromIterator, path::Path};
 
 const ACCEPT_STATE_ID: &str = "accept";
 
-pub fn gen_noir_fn(regex_and_dfa: &RegexAndDFA, path: &Path) -> Result<(), std::io::Error> {
-    let noir_fn = to_noir_fn(regex_and_dfa);
+pub fn gen_noir_fn(
+    regex_and_dfa: &RegexAndDFA,
+    path: &Path,
+    gen_substrs: bool,
+) -> Result<(), std::io::Error> {
+    let noir_fn = to_noir_fn(regex_and_dfa, gen_substrs);
     let mut file = File::create(path)?;
     file.write_all(noir_fn.as_bytes())?;
     file.flush()?;
     Ok(())
 }
 
-fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
+/// Generates Noir code based on the DFA and whether a substring should be extracted.
+///
+/// # Arguments
+///
+/// * `regex_and_dfa` - The `RegexAndDFA` struct containing the regex pattern and DFA.
+/// * `gen_substrs` - A boolean indicating whether to generate substrings. 
+///
+/// # Returns
+///
+/// A `String` that contains the Noir code
+fn to_noir_fn(regex_and_dfa: &RegexAndDFA, gen_substrs: bool) -> String {
     let accept_state_ids = {
         let accept_states = regex_and_dfa
             .dfa
@@ -64,7 +76,7 @@ fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
             &format!("table[{curr_state_id} * {BYTE_SIZE} + {char_code}] = {next_state_id};\n",);
     }
 
-    lookup_table_body = indent(&lookup_table_body);
+    lookup_table_body = indent(&lookup_table_body, 1);
     let table_size = BYTE_SIZE as usize * regex_and_dfa.dfa.states.len();
     let lookup_table = format!(
         r#"
@@ -77,13 +89,78 @@ comptime fn make_lookup_table() -> [Field; {table_size}] {{
     "#
     );
 
+    // substring_ranges contains the transitions that belong to the substring. 
+    //   in Noir we only need to know in what state the substring needs to be extracted, the transitions are not needed
+    //   Example: SubstringDefinitions { substring_ranges: [{(2, 3)}, {(6, 7), (7, 7)}, {(8, 9)}], substring_boundaries: None }
+    //   for each substring, get the first transition and get the end state
+    let substr_states: Vec<usize> = regex_and_dfa
+      .substrings
+      .substring_ranges
+      .iter()
+      .flat_map(|range_set| range_set.iter().next().map(|&(_, end_state)| end_state)) // Extract the second element (end state) of each tuple
+      .collect();
+    // Note: substring_boundaries is only filled if the substring info is coming from decomposed setting
+    //  and will be empty in the raw setting (using json file for substr transitions). This is why substring_ranges is used here
+
     let final_states_condition_body = accept_state_ids
         .iter()
         .map(|id| format!("(s == {id})"))
         .collect_vec()
         .join(" | ");
-    let fn_body = format!(
-        r#"
+
+    // If substrings have to be extracted, the function returns that amount of BoundedVec,
+    // otherwise there is no return type
+    let fn_body = if gen_substrs {
+        let nr_substrs = substr_states.len();
+        // Initialize a substring BoundedVec for each substr that has to be extracted
+        let mut bounded_vecs_initialization = (0..nr_substrs)
+            .map(|index| format!("let mut substr{} = BoundedVec::new();", index))
+            .collect::<Vec<_>>()
+            .join("\n");
+        bounded_vecs_initialization = indent(&bounded_vecs_initialization, 1); // Indent once for inside the function
+
+        // Fill each substring when at the corresponding state
+        let mut conditions = substr_states
+            .iter()
+            .enumerate()
+            .map(|(index, state)| {
+                format!(
+                    "if (s == {state}) {{
+    substr{index_plus_one}.push(temp);
+}}",
+                    index_plus_one = index
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        conditions = indent(&conditions, 2); // Indent twice to align with the for loop's body
+
+        format!(
+            r#"
+global table = comptime {{ make_lookup_table() }};
+pub fn regex_match<let N: u32>(input: [u8; N]) -> [BoundedVec<Field, N>; {nr_substrs}] {{
+    // regex: {regex_pattern}
+    let mut s = 0;
+    
+{bounded_vecs_initialization}
+
+    for i in 0..input.len() {{
+        let temp = input[i] as Field;
+        s = table[s * {BYTE_SIZE} + input[i] as Field];
+{conditions}
+    }}
+    assert({final_states_condition_body}, f"no match: {{s}}");
+    [{bounded_vec_names}]
+}}"#,
+            regex_pattern = regex_and_dfa.regex_pattern,
+            bounded_vec_names = (0..nr_substrs)
+                .map(|index| format!("substr{}", index))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    } else {
+        format!(
+            r#"
 global table = comptime {{ make_lookup_table() }};
 pub fn regex_match<let N: u32>(input: [u8; N]) {{
     // regex: {regex_pattern}
@@ -92,10 +169,11 @@ pub fn regex_match<let N: u32>(input: [u8; N]) {{
         s = table[s * {BYTE_SIZE} + input[i] as Field];
     }}
     assert({final_states_condition_body}, f"no match: {{s}}");
-}}
-    "#,
-        regex_pattern = regex_and_dfa.regex_pattern,
-    );
+}}"#,
+            regex_pattern = regex_and_dfa.regex_pattern,
+        )
+    };
+
     format!(
         r#"
         {fn_body}
@@ -106,13 +184,16 @@ pub fn regex_match<let N: u32>(input: [u8; N]) {{
     .to_owned()
 }
 
-fn indent(s: &str) -> String {
+/// Indents each line of the given string by a specified number of levels.
+/// Each level adds four spaces to the beginning of non-whitespace lines.
+fn indent(s: &str, level: usize) -> String {
+    let indent_str = "    ".repeat(level);
     s.split("\n")
         .map(|s| {
             if s.trim().is_empty() {
                 s.to_owned()
             } else {
-                format!("{}{}", "    ", s)
+                format!("{}{}", indent_str, s)
             }
         })
         .collect::<Vec<_>>()

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -108,28 +108,30 @@ comptime fn make_lookup_table() -> [Field; {table_size}] {{
         .collect_vec()
         .join(" | ");
 
-    // If substrings have to be extracted, the function returns that amount of BoundedVec,
+    // If substrings have to be extracted, the function returns a vector of BoundedVec
     // otherwise there is no return type
     let fn_body = if gen_substrs {
-        let nr_substrs = substr_states.len();
-        // Initialize a substring BoundedVec for each substr that has to be extracted
-        let mut bounded_vecs_initialization = (0..nr_substrs)
-            .map(|index| format!("let mut substr{} = BoundedVec::new();", index))
-            .collect::<Vec<_>>()
-            .join("\n");
-        bounded_vecs_initialization = indent(&bounded_vecs_initialization, 1); // Indent once for inside the function
 
         // Fill each substring when at the corresponding state
+        // Per state potentially multiple substrings should be extracted
+        // The code keeps track of whether a substring was already in the making, or a new one is started
         let mut conditions = substr_states
             .iter()
-            .enumerate()
-            .map(|(index, state)| {
+            .map(|state| {
                 format!(
-                    "if (s == {state}) {{
-    substr{index_plus_one}.push(temp);
-}}",
-                    index_plus_one = index
-                )
+                    "if ((s_next == {state}) & (consecutive_substr == 0)) {{
+  let mut substr0 = BoundedVec::new();
+  substr0.push(temp);
+  substrings.push(substr0);
+  consecutive_substr = 1;
+  substr_count += 1;
+}} else if ((s_next == {state}) & (s == {state})) {{
+  let mut current: BoundedVec<Field, N> = substrings.get(substr_count - 1);
+  current.push(temp);
+  substrings.set(substr_count - 1, current);
+}} else if (s == {state}) {{
+  consecutive_substr = 0;
+}}")
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -138,25 +140,30 @@ comptime fn make_lookup_table() -> [Field; {table_size}] {{
         format!(
             r#"
 global table = comptime {{ make_lookup_table() }};
-pub fn regex_match<let N: u32>(input: [u8; N]) -> [BoundedVec<Field, N>; {nr_substrs}] {{
+pub fn regex_match<let N: u32>(input: [u8; N]) -> Vec<BoundedVec<Field, N>> {{
     // regex: {regex_pattern}
-    let mut s = 0;
-    
-{bounded_vecs_initialization}
+    let mut substrings: Vec<BoundedVec<Field, N>> = Vec::new();
+    // Workaround for pop bug with Vec
+    let mut substr_count = 0;
+
+    // "Previous" state
+    let mut s: Field = 0;
+    // "Next"/upcoming state
+    let mut s_next: Field = 0;
+
+    let mut consecutive_substr = 0;
 
     for i in 0..input.len() {{
         let temp = input[i] as Field;
-        s = table[s * {BYTE_SIZE} + input[i] as Field];
+        s_next = table[s * 256 + temp];
+        // Fill up substrings
 {conditions}
+        s = s_next;
     }}
     assert({final_states_condition_body}, f"no match: {{s}}");
-    [{bounded_vec_names}]
+    substrings
 }}"#,
-            regex_pattern = regex_and_dfa.regex_pattern,
-            bounded_vec_names = (0..nr_substrs)
-                .map(|index| format!("substr{}", index))
-                .collect::<Vec<_>>()
-                .join(", "),
+            regex_pattern = regex_and_dfa.regex_pattern
         )
     } else {
         format!(


### PR DESCRIPTION
Extraction of 1 or more substrings can be requested in both settings (raw, decomposed):
- raw: pass on a json file with `-s <SUBSTRS_JSON_PATH>` that contains the state transitions that should be revealed
- decomposed: mark the part as public

This information is added to `substrings` in the `RegexAndDFA`. In the case of raw only `substring_ranges` is filled so this is what this implementation uses.

## How it works
The adjustments when `gen_substrs = true` are:
- return type of `regex_match` becomes an array length of #substrs, each of which is a BoundedVec. We don't know the substring length beforehand, but it is bounded by N
- fill #substrs of BoundedVec with the bytes when in the corresponding state

If the bool is false, nothing changes. 

Note: For the raw setting the boolean was by default set to true, I changed it to false, just like in the decomposed setting. Asked in the TG group if this is ok. 

## Testing

### Decomposed

Create a file called `substring_test.json` containing:
```
{
  "parts":[
      {
          "is_public": false,
          "regex_def": "email was meant for @"
      },
      {
          "is_public": true,
          "regex_def": "[a-z]+"
      },
      {
          "is_public": false,
          "regex_def": "\\. And the next substring:"
      },
      {
          "is_public": true,
          "regex_def": "[a-z]+"
      }
  ]
}
```
Run
```
cargo run --bin zk-regex decomposed -d substring_test.json --noir-file-path testfile.nr -g true
```

### Raw

This is the example from the README.md; create `./simple_regex_substrs.json` containing:
```
    {
        "transitions": [
            [
                [
                    2,
                    3
                ]
            ],
            [
                [
                    6,
                    7
                ],
                [
                    7,
                    7
                ]
            ],
            [
                [
                    8,
                    9
                ]
            ]
        ]
    }
```
Run
```
cargo run --bin zk-regex raw -r "1=(a|b) (2=(b|c)+ )+d" -s ./simple_regex_substrs.json --noir-file-path simple_regex_substrs.nr -g true`

```

Note that the second substring is marked by 2 transitions [6,7] and [7,7], which is needed for the circom impl. However, in Noir we only need to know the substring is in state 7, so this is the information that is taken from `substring_ranges`.